### PR TITLE
Rewrite templates for multimedia

### DIFF
--- a/multimedia/templates/multimedia/base_list.html
+++ b/multimedia/templates/multimedia/base_list.html
@@ -20,7 +20,8 @@
             </div>
             <div class="media-body">
               <h4 class="media-heading"><a href="{{ item.url }}">{{ item.name }}</a></h4>
-              <p>Item info eg author, singer, isbn, version, price here</p>
+              <!-- Item info eg author, singer, isbn, version, price here -->
+              {% block info %}{% endblock info %}
             </div>
           </div>
         </div>

--- a/multimedia/templates/multimedia/base_list.html
+++ b/multimedia/templates/multimedia/base_list.html
@@ -4,7 +4,7 @@
 {% block content %}
 {{ block.super }}
 <!-- type is either book, movie, application, etc -->
-<h2>{{ type }} List</h2>
+<h2>{{ multimedia_type }} List</h2>
 <div class="container">
   <ul class="list-unstyled">
     {% for item in multimedia %}

--- a/multimedia/templates/multimedia/base_list.html
+++ b/multimedia/templates/multimedia/base_list.html
@@ -1,0 +1,32 @@
+{% extends "multimedia/base.html" %}
+{% load staticfiles %}
+
+{% block content %}
+{{ block.super }}
+<!-- type is either book, movie, application, etc -->
+<h2>{{ type }} List</h2>
+<div class="container">
+  <ul class="list-unstyled">
+    {% for item in multimedia %}
+    <li>
+      <div class="panel">
+        <div class="panel-body">
+          <div class="media">
+            <div class="media-left media-middle">
+              <!-- Insert thumbnail here -->
+              <a href="{{ item.url }}">
+                <img class="media-object" src="#">
+              </a>
+            </div>
+            <div class="media-body">
+              <h4 class="media-heading"><a href="{{ item.url }}">{{ item.name }}</a></h4>
+              <p>Item info eg author, singer, isbn, version, price here</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock content %}

--- a/multimedia/templates/multimedia/book_list.html
+++ b/multimedia/templates/multimedia/book_list.html
@@ -9,3 +9,16 @@ Books - Digital Content Store
 {{ block.super }}
 <link href="{% static "css/book_list.css" %}" rel="stylesheet">
 {% endblock css %}
+
+{% block info %}
+<p>
+  <dl>
+    <dt>Author</dt>
+    <dd>{{ item.author }}</dd>
+    <dt>ISBN13</dt>
+    <dd>{{ item.isbn13 }}</dd>
+    <dt>Price</dt>
+    <dd>???</dd>
+  </dl>
+</p>
+{% endblock info %}

--- a/multimedia/templates/multimedia/book_list.html
+++ b/multimedia/templates/multimedia/book_list.html
@@ -5,19 +5,36 @@
 Books - Digital Content Store
 {% endblock title %}
 
+{% block css %}
+{{ block.super }}
+<link href="{% static "css/book_list.css" %}" rel="stylesheet">
+{% endblock css %}
+
 {% block content %}
 {{ block.super }}
 <h2>Book List</h2>
-<link href="{% static "css/book_list.css" %}" rel="stylesheet">
-
-<ul>
-  {% for book in books %}
-    <div class="book_container">
-      <div style="width:169px; height:255px; background-color:green">
+<div class="container">
+  <ul class="list-unstyled">
+    {% for book in books %}
+    <li>
+      <div class="panel">
+        <div class="panel-body">
+          <div class="media">
+            <div class="media-left media-middle">
+              <!-- Insert thumbnail here -->
+              <a href="{{ book.url }}">
+                <img class="media-object" src="#">
+              </a>
+            </div>
+            <div class="media-body">
+              <h4 class="media-heading"><a href="{{ book.url }}">{{ book.name }}</a></h4>
+              <p>Book info eg author, isbn etc here</p>
+            </div>
+          </div>
+        </div>
       </div>
-      <a class="book_name" href="{{ book.url }}">{{ book.name }}</a>
-    </div>
-  {% endfor %}
-</ul>
-
+    </li>
+    {% endfor %}
+  </ul>
+</div>
 {% endblock content %}

--- a/multimedia/templates/multimedia/book_list.html
+++ b/multimedia/templates/multimedia/book_list.html
@@ -1,4 +1,4 @@
-{% extends "multimedia/book_base.html" %}
+{% extends "multimedia/base_list.html" %}
 {% load staticfiles %}
 
 {% block title %}
@@ -9,32 +9,3 @@ Books - Digital Content Store
 {{ block.super }}
 <link href="{% static "css/book_list.css" %}" rel="stylesheet">
 {% endblock css %}
-
-{% block content %}
-{{ block.super }}
-<h2>Book List</h2>
-<div class="container">
-  <ul class="list-unstyled">
-    {% for book in books %}
-    <li>
-      <div class="panel">
-        <div class="panel-body">
-          <div class="media">
-            <div class="media-left media-middle">
-              <!-- Insert thumbnail here -->
-              <a href="{{ book.url }}">
-                <img class="media-object" src="#">
-              </a>
-            </div>
-            <div class="media-body">
-              <h4 class="media-heading"><a href="{{ book.url }}">{{ book.name }}</a></h4>
-              <p>Book info eg author, isbn etc here</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    {% endfor %}
-  </ul>
-</div>
-{% endblock content %}

--- a/multimedia/views.py
+++ b/multimedia/views.py
@@ -4,7 +4,7 @@ from .models import Book
 
 def book_list(request):
     books = Book.objects.all()
-    return render(request, 'multimedia/book_list.html', {'multimedia': books, 'type': 'Book'})
+    return render(request, 'multimedia/book_list.html', {'multimedia': books, 'multimedia_type': 'Book'})
 
 
 def book_detail(request, isbn13):

--- a/multimedia/views.py
+++ b/multimedia/views.py
@@ -4,7 +4,7 @@ from .models import Book
 
 def book_list(request):
     books = Book.objects.all()
-    return render(request, 'multimedia/book_list.html', {'books': books})
+    return render(request, 'multimedia/book_list.html', {'multimedia': books, 'type': 'Book'})
 
 
 def book_detail(request, isbn13):

--- a/statics/css/book_list.css
+++ b/statics/css/book_list.css
@@ -1,13 +1,11 @@
-.book_container {
-  width:169px;
-  height:350px;
+.book-name {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  white-space: nowrap;
 }
 
-.book_name {
-  width:169px;
-  overflow:hidden;
-  text-overflow:ellipsis;
-  display:block;
-  white-space:nowrap;
+body {
+    background-color: #9CE5D5;
 }
-


### PR DESCRIPTION
Now all multimedia extends from the same template for both list and detail.
So the hierarchy of the templates are:
base.html -> multimedia/base.html -> base_list.html -> {{multimedia_type}}_list.html
base.html -> multimedia/base.html -> base_detail.html -> {{multimedia_type}}_detail.html
## Using base_list.html template

Blocks to be filled:
- `css`
- `js`
- `title` (Page title at the top of the browser)

Variables to be supplied at `views.py`:
- `multimedia` (all the books/apps/whatever)
- 'type' (eg Books, Applications, etc)
## Using base_detail.html template

Blocks to be filled:
- `css`
- `js`
- `title`
- `preview` (the thumbnail and the other aux data to be put below, like price?)
- `description` (the description, and other aux data)

Variables to be supplied at `views.py`:
- 'reviews`

Will write it to README if necessary
