### PR TITLE
Fix Book URL Suffix

### DIFF
--- a/multimedia/managers.py
+++ b/multimedia/managers.py
@@ -174,7 +174,7 @@ class MultimediaManager(models.Manager):
             m.description AS description,
             m.price AS price,
             'books' AS url_prefix,
-            b.isbn13 AS url_suffix
+            m.id AS url_suffix
         FROM multimedia m, book b
         WHERE m.id = b.multimedia_id
     '''


### PR DESCRIPTION
The Book is now use `multimedia_id` instead of isbn13 https://github.com/exclusive-gix/cs2102-store/commit/55ac8527ef19a8c0717804d4881401488120338a
